### PR TITLE
OperationId is same for Two Api in the MWDI latest specification,

### DIFF
--- a/spec/MicroWaveDeviceInventory.yaml
+++ b/spec/MicroWaveDeviceInventory.yaml
@@ -2465,7 +2465,7 @@ paths:
       - $ref: '#/components/parameters/trace-indicator'
       - $ref: '#/components/parameters/customer-journey'
     post:
-      operationId: provideDataOfLinks
+      operationId: provideDataOfLinkPorts
       summary: 'Provides data of linkports in cache'
       tags:
         - IndividualServices


### PR DESCRIPTION
Fixes #1062