### PR TITLE
API "/v1/provide-list-of-cached-devices" should assign a array for devices for key "mount-name-list"

### DIFF
--- a/spec/MicroWaveDeviceInventory.yaml
+++ b/spec/MicroWaveDeviceInventory.yaml
@@ -2983,13 +2983,10 @@ paths:
                   mount-name-list:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        mount-name:
-                          type: string
-                          description: >
-                            'MountName of the device for which MWDI has a cached ControlConstruct
-                            from {$RequestForListOfCachedDevicesCausesReadingFromCache}'
+                      type: string
+                      description: >
+                        'MountName of the device for which MWDI has a cached ControlConstruct
+                        from {$RequestForListOfCachedDevicesCausesReadingFromCache}'
               example:
                 mount-name-list:
                   - '305251234'


### PR DESCRIPTION
Fixes #1466